### PR TITLE
Chain api resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,55 @@ yarn health     # prints chain info and current head
 
 See [infra/README.md](infra/README.md) for details.
 
+### Local node (Docker Compose)
+
+Run the stack with an embedded Autonomys node using the `local-node` profile. An override compose file ensures `scheduler` waits for the node to be healthy when this profile is enabled.
+
+1. Copy env and adjust values
+
+```bash
+cp infra/compose/.env.example infra/compose/.env
+# edit NODE_DOCKER_TAG, NETWORK_ID (and optionally DOMAIN_ID)
+# set ACCOUNT_PRIVATE_KEY, TIP_AI3, DAILY_CAP_AI3, etc.
+```
+
+2. Start with local-node profile (using override file)
+
+```bash
+docker compose \
+  -f infra/compose/docker-compose.yml \
+  -f infra/compose/docker-compose.local-node.yml \
+  --profile local-node up -d --build
+```
+
+Alternatively, set the compose files once in your shell and then run compose normally:
+
+```bash
+export COMPOSE_FILE=infra/compose/docker-compose.yml:infra/compose/docker-compose.local-node.yml
+docker compose --profile local-node up -d --build
+```
+
+3. Verify
+
+```bash
+# API via Nginx proxy
+curl -s http://127.0.0.1:${PROXY_HOST_PORT:-80}/health | jq .
+
+# Optional: check embedded node JSON-RPC directly
+curl -s -H 'Content-Type: application/json' \
+  -d '{"id":1,"jsonrpc":"2.0","method":"system_health","params":[]}' \
+  http://127.0.0.1:9944/ | jq .
+```
+
+4. Shutdown
+
+```bash
+docker compose \
+  -f infra/compose/docker-compose.yml \
+  -f infra/compose/docker-compose.local-node.yml \
+  --profile local-node down
+```
+
 ## Documentation
 
 See [docs/README.md](docs/README.md) for more detailed documentation.

--- a/infra/compose/docker-compose.local-node.yml
+++ b/infra/compose/docker-compose.local-node.yml
@@ -1,0 +1,5 @@
+services:
+  scheduler:
+    depends_on:
+      node:
+        condition: service_healthy

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       [
         'run',
         '--chain',
-        '${NETWORK_ID}',
+        '${NETWORK_ID:-mainnet}',
         '--base-path',
         '/var/subspace',
         '--',

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -31,13 +31,14 @@ services:
     restart: unless-stopped
     volumes:
       - node_data:/var/subspace:rw
-    command:
-      [
+    command: [
         'run',
         '--chain',
         '${NETWORK_ID:-mainnet}',
         '--base-path',
         '/var/subspace',
+        '--sync',
+        'full', # On initial sync "snap" sync can be used. Once https://github.com/autonomys/subspace/issues/3555 is fixed, we can remove this flag, as the default "snap" sync will always work
         '--',
         '--domain-id',
         '${DOMAIN_ID:-0}',

--- a/src/chain/api.ts
+++ b/src/chain/api.ts
@@ -6,37 +6,8 @@ import { logger } from '../logger.js';
 let apiInstance: ApiPromise | null = null;
 let providerInstance: WsProvider | null = null;
 
-const cleanupApi = async (reason: string, err?: unknown): Promise<void> => {
-  try {
-    if (err) {
-      logger.warn({ err, reason }, 'cleaning up chain api due to error');
-    } else {
-      logger.info({ reason }, 'cleaning up chain api');
-    }
-    if (apiInstance) {
-      try {
-        await apiInstance.disconnect();
-      } catch (e) {
-        logger.warn({ err: e }, 'error disconnecting ApiPromise');
-      }
-    }
-    if (providerInstance) {
-      try {
-        await providerInstance.disconnect();
-      } catch (e) {
-        logger.warn({ err: e }, 'error disconnecting WsProvider');
-      }
-    }
-  } finally {
-    apiInstance = null;
-    providerInstance = null;
-  }
-};
-
-export const getApi = async (): Promise<ApiPromise> => {
-  if (apiInstance && apiInstance.isConnected) {
-    return apiInstance;
-  }
+const getOrCreateProvider = (): WsProvider => {
+  if (providerInstance) return providerInstance;
 
   const cfg = loadConfig();
   const provider = new WsProvider(cfg.rpcEndpoints);
@@ -44,29 +15,62 @@ export const getApi = async (): Promise<ApiPromise> => {
 
   provider.on('connected', () => {
     logger.info({ endpoints: cfg.rpcEndpoints }, 'chain connected');
+    logger.info({ connectedEndpoint: provider.endpoint }, 'connected endpoint');
   });
+
   provider.on('disconnected', () => {
     logger.warn('chain disconnected');
-    void cleanupApi('provider_disconnected');
+    // Do not tear down; allow WsProvider to auto-rotate/retry
   });
+
   provider.on('error', (err) => {
     logger.error({ err }, 'chain provider error');
-    void cleanupApi('provider_error', err);
+    // Do not tear down; allow WsProvider to auto-rotate/retry
   });
 
-  const api = await ApiPromise.create({ provider });
-  await api.isReadyOrError;
+  return providerInstance;
+};
 
-  api.on('error', (err) => {
-    logger.error({ err }, 'chain api error');
-    void cleanupApi('api_error', err);
-  });
+export const getApi = async (): Promise<ApiPromise> => {
+  if (apiInstance && apiInstance.isConnected) {
+    return apiInstance;
+  }
 
-  logger.info('chain api ready');
-  apiInstance = api;
+  const provider = getOrCreateProvider();
+
+  if (!apiInstance) {
+    apiInstance = await ApiPromise.create({ provider });
+
+    apiInstance.on('error', (err) => {
+      logger.error({ err }, 'chain api error');
+      // Keep provider alive; ApiPromise will recover when provider reconnects
+    });
+
+    await apiInstance.isReadyOrError;
+    logger.info('chain api ready');
+  }
+
   return apiInstance;
 };
 
 export const disconnectApi = async (): Promise<void> => {
-  await cleanupApi('manual_disconnect');
+  if (apiInstance) {
+    try {
+      await apiInstance.disconnect();
+    } catch (e) {
+      logger.warn({ err: e }, 'error disconnecting ApiPromise');
+    } finally {
+      apiInstance = null;
+    }
+  }
+
+  if (providerInstance) {
+    try {
+      await providerInstance.disconnect();
+    } catch (e) {
+      logger.warn({ err: e }, 'error disconnecting WsProvider');
+    } finally {
+      providerInstance = null;
+    }
+  }
 };


### PR DESCRIPTION
This pull request introduces improvements to local development and deployment workflows, particularly for running the stack with an embedded Autonomys node using Docker Compose. It adds new documentation for the local-node setup, updates Docker Compose configurations to better support local node usage, and refactors the chain API connection logic for greater reliability.

**Local-node deployment enhancements:**

* Added detailed instructions in `README.md` for running the stack with an embedded node using the `local-node` Docker Compose profile, including environment setup, startup, verification, and shutdown steps.
* Updated `infra/compose/docker-compose.local-node.yml` to ensure the `scheduler` service waits for the embedded node to be healthy before starting, improving startup reliability.
* Clarified in documentation that the `node` service only starts with the `local-node` profile, and described port forwarding and connection defaults for the embedded node.

**Docker Compose and configuration improvements:**

* Modified the `node` service command in `infra/compose/docker-compose.yml` to use sensible defaults for `NETWORK_ID` and `DOMAIN_ID`, and added a `--sync full` flag for improved initial sync reliability.
* Removed a note about destructive volume removal from documentation, streamlining instructions.
* Removed a reference to reserved systemd unit files, simplifying the structure documentation.

**Chain API connection reliability:**

* Refactored `src/chain/api.ts` to separate provider creation from API instantiation, allowing the WebSocket provider to auto-reconnect and rotate endpoints without tearing down the API connection, which improves resilience to network errors and reconnections.